### PR TITLE
Downgrade Microsoft.Azure.Functions.Worker.Extensions.EventGrid

### DIFF
--- a/src/backend/Directory.Packages.props
+++ b/src/backend/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.4.3" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.4.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />

--- a/src/backend/global.json
+++ b/src/backend/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.101",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated SDK version to 9.0.101
	- Adjusted package version for `Microsoft.Azure.Functions.Worker.Extensions.EventGrid` to 3.4.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->